### PR TITLE
Parameterize the cache key type

### DIFF
--- a/src/gacache.gleam
+++ b/src/gacache.gleam
@@ -11,7 +11,6 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-//  limitations under the License.
 import gleam/dict
 import gleam/erlang/process
 import gleam/otp/actor

--- a/src/gacache.gleam
+++ b/src/gacache.gleam
@@ -11,19 +11,17 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
+//  limitations under the License.
 import gleam/dict
 import gleam/erlang/process
 import gleam/otp/actor
 import gleam/result
 
-type Key =
-  String
+type Store(key, value) =
+  dict.Dict(key, value)
 
-type Store(value) =
-  dict.Dict(Key, value)
-
-type Cache(value) =
-  process.Subject(Action(value))
+type Cache(key, value) =
+  process.Subject(Action(key, value))
 
 pub type Error {
   /// Provided when the Get Action is sent with a Key that has no corresponding Value
@@ -32,26 +30,26 @@ pub type Error {
   Timeout
 }
 
-/// Actions are passed to the Cache to interact with it's Store
-pub type Action(value) {
-  Set(key: Key, value: value)
-  Get(ret: process.Subject(Result(value, Error)), key: Key)
-  Clear(key: Key)
-  Keys(ret: process.Subject(List(Key)))
+/// Actions are passed to the Cache to interact with its Store
+pub type Action(key, value) {
+  Set(key: key, value: value)
+  Get(ret: process.Subject(Result(value, Error)), key: key)
+  Clear(key: key)
+  Keys(ret: process.Subject(List(key)))
   Reset
-  Raw(ret: process.Subject(Store(value)))
-  Merge(store: Store(value))
+  Raw(ret: process.Subject(Store(key, value)))
+  Merge(store: Store(key, value))
   Stop
 }
 
 /// Start the cache
-pub fn start() -> Result(Cache(value), actor.StartError) {
+pub fn start() -> Result(Cache(key, value), actor.StartError) {
   actor.start(dict.new(), process_action)
 }
 
 /// Internal handling for Actions
 /// Performs Actions on the Store
-fn process_action(action: Action(value), store: Store(value)) {
+fn process_action(action: Action(key, value), store: Store(key, value)) {
   case action {
     Set(key, value) -> dict.insert(store, key, value) |> actor.continue
     Get(ret, key) -> {
@@ -74,40 +72,40 @@ fn process_action(action: Action(value), store: Store(value)) {
 }
 
 /// Updates the Store with key=value
-pub fn set(cache: Cache(value), key: Key, value: value) {
+pub fn set(cache: Cache(key, value), key: key, value: value) {
   process.send(cache, Set(key, value))
 }
 
-pub fn get(cache: Cache(value), key: Key) -> Result(value, Error) {
+pub fn get(cache: Cache(key, value), key: key) -> Result(value, Error) {
   process.try_call(cache, Get(_, key), 10_000) |> result.unwrap(Error(Timeout))
 }
 
 /// Removes the Value associated with the provided Key from the Store
-pub fn clear(cache: Cache(value), key: Key) {
+pub fn clear(cache: Cache(key, value), key: key) {
   process.send(cache, Clear(key))
 }
 
 /// Returns all keys known by the Store
-pub fn keys(cache: Cache(value)) -> List(Key) {
+pub fn keys(cache: Cache(key, value)) -> List(key) {
   process.try_call(cache, Keys(_), 10_000) |> result.unwrap([])
 }
 
 /// Clears the whole Store
-pub fn reset(cache: Cache(value)) {
+pub fn reset(cache: Cache(key, value)) {
   process.send(cache, Reset)
 }
 
 /// Returns the Store, avoid if possible
-pub fn raw(cache: Cache(value)) -> Result(Store(value), Error) {
+pub fn raw(cache: Cache(key, value)) -> Result(Store(key, value), Error) {
   process.try_call(cache, Raw(_), 10_000) |> result.replace_error(Timeout)
 }
 
 /// Merges the Store with the provided Store using dict:merge/2
-pub fn merge(cache: Cache(value), new_store: Store(value)) {
+pub fn merge(cache: Cache(key, value), new_store: Store(key, value)) {
   process.send(cache, Merge(new_store))
 }
 
 /// Stops the cache
-pub fn stop(cache: Cache(value)) {
+pub fn stop(cache: Cache(key, value)) {
   process.send(cache, Stop)
 }


### PR DESCRIPTION
This allows any type to be used as a key in the cache, as discussed in #2. No worries if you can't merge this for some reason. I just already made the change, so I thought I would open this in case it was useful. Thanks again for the package, cheers!